### PR TITLE
feat: add vE!/vS! notation entry points and multi-packed-dims

### DIFF
--- a/VerilLean/Lang/Notation.lean
+++ b/VerilLean/Lang/Notation.lean
@@ -633,8 +633,11 @@ macro_rules
 macro_rules
   | `(vpackeddim| [ $l:vexpr : $r:vexpr ]) => `((dim.range $l $r : packed_dims))
   | `(vpackeddim| [ $d:vexpr ]) => `((dim.one $d : packed_dims))
-  | `(vpackeddim| $a:vpackeddim $b:vpackeddim) =>
-    `(packed_dims.cons $a $b)
+  -- Multi-packed-dims: [a:b][c:d] → cons (first dim) (rest as packed_dims)
+  | `(vpackeddim| [ $l:vexpr : $r:vexpr ] $b:vpackeddim) =>
+    `(packed_dims.cons (dim.range $l $r) $b)
+  | `(vpackeddim| [ $d:vexpr ] $b:vpackeddim) =>
+    `(packed_dims.cons (dim.one $d) $b)
 
 -- ### vport -> term
 
@@ -879,8 +882,20 @@ macro_rules
   | `(vtop| module $n:ident #( $params:vparamport ) ( $ports:vport ) ; $items:vmoditem endmodule) => do
     let s ← idToStr n; `(module_decl.ansi $s $params $ports $items)
 
--- ### Entry point
+-- ### Entry points
+
+-- Module declaration entry point.
 macro_rules
   | `(v![ $t:vtop ]) => `($t)
+
+-- Expression entry point: parse a single Verilog expression.
+syntax "vE![" vexpr "]" : term
+macro_rules
+  | `(vE![ $e:vexpr ]) => `($e)
+
+-- Statement entry point: parse a single Verilog statement.
+syntax "vS![" vstmt "]" : term
+macro_rules
+  | `(vS![ $s:vstmt ]) => `($s)
 
 end VerilLean.Lang.Notation

--- a/VerilLean/Lang/Tester.lean
+++ b/VerilLean/Lang/Tester.lean
@@ -128,3 +128,21 @@ def tester6 : module_decl := v![
     module_a module_ins_a (.*, .net_a, .net_a(), .net_a(net_a), .*);
   endmodule
 ]
+
+-- Multi-packed-dimension arrays and expression entry points
+def tester7 : module_decl := v![
+  module tester
+    #(parameter integer ADDR_SIZE = 32,
+      parameter integer DATA_SIZE = 32)
+    (input logic clk,
+     input logic rst_n);
+    localparam integer MEM_SIZE = 2 ** (ADDR_SIZE - 2) ;
+    logic [MEM_SIZE-1:0][DATA_SIZE-1:0] mem ;
+  endmodule
+]
+
+-- vE![] entry point
+def tester_expr : expression := vE![ a + b * c ]
+
+-- vS![] entry point
+def tester_stmt : statement := vS![ a = b + c ; ]


### PR DESCRIPTION
## Summary

Utilities needed for downstream verification case studies (e.g., RvCore).

- **`vE![...]` / `vS![...]`**: Standalone expression/statement notation entry points, complementing `v![...]` for modules. Enables proof-oriented decomposition where function bodies are defined as separate `expression` terms.
- **Multi-packed-dims**: `logic [X:0][Y:0] mem` did not handle multi-dimensional packed arrays (`packed_dims.cons` received `packed_dims` instead of `dim`). Required for cache/memory modeling.